### PR TITLE
Fix outdated links

### DIFF
--- a/ss_to_json/index.html
+++ b/ss_to_json/index.html
@@ -32,8 +32,8 @@
       </div>
       <div class="row">
         <p>Загружай ключ Outline, который начинается на ss://</p>
-        <p>Используется эта библиотека для расшифровки и перевода в json: <a class="link-dark" href="https://github.com/Paulo1312/ss_to_json_rust">https://github.com/Paulo1312/ss_to_json_rust</a></p>
-        <p>Все вычисления происходят на твоём устройстве. Если не доверяешь - можешь воспользоваться десктопной программой (Консольной) <a class="link-dark" href="https://github.com/Paulo1312/ss_to_json_rust">https://github.com/Paulo1312/ss_to_json_rust</a></p>
+        <p>Используется эта библиотека для расшифровки и перевода в json: <a class="link-dark" href="https://github.com/Paulo1312/ss_to_json_outline_rust">https://github.com/Paulo1312/ss_to_json_outline_rust</a></p>
+        <p>Все вычисления происходят на твоём устройстве. Если не доверяешь - можешь воспользоваться десктопной программой (Консольной) <a class="link-dark" href="https://github.com/Paulo1312/ss_to_json_outline_rust">https://github.com/Paulo1312/ss_to_json_outline_rust</a></p>
         <p>Либо скачать сайт и запустить у себя на устройстве</p>
 
       </div>


### PR DESCRIPTION
Fix links to [Paulo1312/ss_to_json_outline_rust](https://github.com/Paulo1312/ss_to_json_outline_rust) (that has been named `ss_to_json_rust` previously, I guess)